### PR TITLE
Added power_graph

### DIFF
--- a/graphs/graph.py
+++ b/graphs/graph.py
@@ -27,9 +27,9 @@ class graph:
         return self.isDirected
 
     def add_edge(self, i, j):
-        if i < 1 or i > self.vertices:
+        if i < 0 or i > self.vertices - 1:
             raise Exception("Source vertex out of range")
-        elif j < 1 or j > self.vertices:
+        elif j < 0 or j > self.vertices - 1:
             raise Exception("Destination vertex out of range")
         elif i == j:
             raise Exception("Self loops forbidden")
@@ -38,3 +38,17 @@ class graph:
 
         if not self.isDirected:
             self.edges.add((j, i))
+
+def power_graph(g):
+    """
+    Takes the multiplication table of a magma as
+    g:[[int]] and returns its undirected power graph
+    """
+    n = len(g)
+    Gamma = graph(n, set(()), False)
+    for i in range(n):
+        j = g[i][i] 
+        while j != i:
+            Gamma.add_edge(i, j)
+            j = g[i][j]
+    return Gamma

--- a/graphs/graph_visualize.py
+++ b/graphs/graph_visualize.py
@@ -11,7 +11,7 @@ def visualize_graph(g):
     """
     print("\\begin{tikzpicture}")
 
-    vertices = [i + 1 for i in range(g.size())]
+    vertices = [i for i in range(g.size())]
     for i in vertices:
         print("\\node (" + str(i) + ") at (" + str(i%2) + ", " +
             str(i//2) + "){$" + str(i) + "$};")
@@ -26,6 +26,7 @@ def visualize_graph(g):
     else:
         print("\\draw", end = "")
         for j in g.get_edges():
+            print("")
             print("(" + str(j[0]) + ") -- (" + str(j[1]) + ")", end = "")
     print(";")
     print("\\end{tikzpicture}")


### PR DESCRIPTION
Added power_graph which generates the undirected power graph
of a power associative magma given its multiplication table.
Example:
power_graph([[0, 1, 2], [1, 2, 0], [2, 0, 1]])
Returns the undirected power graph of the cyclic group of
order 3.